### PR TITLE
Makes forceatlas2_igraph_layout compatible with scipy 1.13.0

### DIFF
--- a/fa2_modified/forceatlas2.py
+++ b/fa2_modified/forceatlas2.py
@@ -272,7 +272,7 @@ class ForceAtlas2:
                 edges.extend([(v, u) for u, v in edges])
                 weights.extend(weights)
 
-            return csr_matrix((weights, zip(*edges)))
+            return csr_matrix((weights, list(zip(*edges))))
 
         assert isinstance(G, igraph.Graph), "Not a igraph graph"
         assert isinstance(pos, (list, numpy.ndarray)) or (pos is None), "pos must be a list or numpy array"


### PR DESCRIPTION
Hello,

Nice to see some changes for this project.
The `ForceAtlas2.forceatlas2_igraph_layout` function has a problem with the latest scipy.
Indeed, the call to csr_matrix on line 267 with a zip argument leads to a `TypeError`:
```
  File "...\fa2\forceatlas2.py", line 275, in forceatlas2_igraph_layout
    adj = to_sparse(G, weight_attr)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...\fa2\forceatlas2.py", line 267, in to_sparse
    return csr_matrix((weights, zip(*edges)))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...\scipy\sparse\_compressed.py", line 55, in __init__
    coo = self._coo_container(arg1, shape=shape, dtype=dtype)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...\scipy\sparse\_coo.py", line 54, in __init__
    self._shape = check_shape(shape, allow_1d=is_array)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...\scipy\sparse\_sputils.py", line 317, in check_shape
    raise TypeError("function missing 1 required positional argument: "
TypeError: function missing 1 required positional argument: 'shape'
```
This is because the zip object is iterated two times in a row in [scipy](https://github.com/scipy/scipy/blob/a4ccee201d1069d2b324c79d5bc2b1e66713182b/scipy/sparse/_coo.py#L49) and is empty the second time.
Converting the zip object to a list before calling `csr_matrix` fix the problems.

Regards